### PR TITLE
modify uwsgi ini task to allow uwsgi to start

### DIFF
--- a/tasks/deploy_webapp.yml
+++ b/tasks/deploy_webapp.yml
@@ -15,7 +15,8 @@
     src: uwsgi.ini.j2
     dest: '{{ django_path }}/uwsgi.ini'
   notify: Reload uwsgi
-  when: uwsgi_pid_file.stat.exists
+  # disabled because it uwsgi fails to start if it can't find the config file
+  # when: uwsgi_pid_file.stat.exists
 
 - name: Uwsgi conf present
   become: yes
@@ -24,7 +25,7 @@
     state: present
   when: uwsgi_conf.changed
   register: uwsgi_present
-  
+
 - name: Uwsgi supervisor updated & restarted
   become: yes
   supervisorctl:


### PR DESCRIPTION
disabled because it uwsgi fails to start if it can't find the config file which is created by the 'uwsgi ini' task
